### PR TITLE
CacheDir option removed because it might cause problems with permissions...

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Ubuntu or Debian
 
 ## Role Variables
 * `apt_cacher_ng_port: 3142`
-* `apt_cacher_ng_cache_dir: /var/cache/apt-cacher-ng`
 * `apt_cacher_ng_setup_ufw: True` Add a ufw rule to allow apt-cacher-ng
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 # defaults file for apt-cacher-ng
 apt_cacher_ng_port: 3142
-apt_cacher_ng_cache_dir: /var/cache/apt-cacher-ng
 apt_cacher_ng_setup_ufw: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,14 +6,10 @@
 - name: Enable apt-cacher-ng on boot
   service: name=apt-cacher-ng state=started enabled=yes
 
-- name: Create CacheDir
-  file: path={{ apt_cacher_ng_cache_dir }} owner=root group=root mode=755 state=directory
-
 - name: Set config
   lineinfile: dest=/etc/apt-cacher-ng/acng.conf regexp={{ item.regexp | default(omit) }} line="{{ item.line }}" state={{ item.state | default("present") }}
   with_items:
     - { regexp: "^Port:", line: "Port: {{ apt_cacher_ng_port }}" }
-    - { regexp: "^CacheDir:\ ", line: "CacheDir: {{ apt_cacher_ng_cache_dir }}" }
 
 - name: Allow apt-cacher-ng (Firewall)
   ufw: rule=allow port={{ apt_cacher_ng_port }} proto=tcp


### PR DESCRIPTION
Hi elnappo,

I made this change because this role changes the ownership of the cache dir to root:root.
Debian and ubuntu use an special user and group apt-cacher-ng:apt-cacher-ng.

When the role changes the default ownership of the cache directory, apt-cacher-ng stops working because the user apt-cacher-ng does not have permission to write in the directory root:root.  The apt-cacher-ng gives a 503 status message: https://www.unix-ag.uni-kl.de/~bloch/acng/html/troublefaq.html#prob

I've deleted the role variable because I think it's the simplest solution.
(an alternative could be to check ansible_distribution, etc. and set the user and group accordingly)

Tested in the Vagrant machine hashicorp/precise32: 
Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic-pae i686)
