### PR TITLE
Add a proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Ubuntu or Debian
 * `apt_cacher_ng_port: 3142`
 * `apt_cacher_ng_cache_dir: /var/cache/apt-cacher-ng`
 * `apt_cacher_ng_setup_ufw: True` Add a ufw rule to allow apt-cacher-ng
+* `apt_cacher_ng_setup_proxy: true` Add a proxy to apt-cacher-ng
+* `apt_cacher_ng_proxy_ip: 10.0.0.1`
+* `apt_cacher_ng_proxy_port: 3128`
 
 ## Dependencies
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@
 apt_cacher_ng_port: 3142
 apt_cacher_ng_cache_dir: /var/cache/apt-cacher-ng
 apt_cacher_ng_setup_ufw: true
+apt_cacher_ng_setup_proxy: true
+apt_cacher_ng_proxy_ip: 10.0.0.1
+apt_cacher_ng_proxy_port: 3128

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,19 @@
   with_items:
     - { regexp: "^Port:", line: "Port: {{ apt_cacher_ng_port }}" }
     - { regexp: "^CacheDir:\ ", line: "CacheDir: {{ apt_cacher_ng_cache_dir }}" }
+    - { regexp: "^Proxy:\ ", line: "Proxy: {{ apt_cacher_ng_proxy_ip }}:{{ apt_cacher_ng_proxy_port }}" }
+  notify:
+    - restart apt-cacher-ng
+
+- name: Set proxy config
+  lineinfile:
+    dest: /etc/apt-cacher-ng/acng.conf
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: "{{ item.state | default('present') }}"
+  with_items:
+    - { regexp: "^Proxy:\ ", line: "Proxy: {{ apt_cacher_ng_proxy_ip }}:{{ apt_cacher_ng_proxy_port }}" }
+  when: apt_cacher_ng_setup_proxy == true
   notify:
     - restart apt-cacher-ng
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,6 @@
   with_items:
     - { regexp: "^Port:", line: "Port: {{ apt_cacher_ng_port }}" }
     - { regexp: "^CacheDir:\ ", line: "CacheDir: {{ apt_cacher_ng_cache_dir }}" }
-    - { regexp: "^Proxy:\ ", line: "Proxy: {{ apt_cacher_ng_proxy_ip }}:{{ apt_cacher_ng_proxy_port }}" }
   notify:
     - restart apt-cacher-ng
 


### PR DESCRIPTION
Add 3 new variables to indicate the proxy configuration. If the apt_cacher_ng_setup_proxy variable is set to TRUE, the proxy configuration will be added in the /etc/apt-cacher-ng/acng.conf file.